### PR TITLE
fix uuid error

### DIFF
--- a/bunq.go
+++ b/bunq.go
@@ -34,7 +34,7 @@ func NewClient() *Client {
 func setCommonHeaders(r *http.Request) {
 	r.Header.Set("Cache-Control", "no-cache")
 	r.Header.Set("User-Agent", userAgent)
-	r.Header.Set("X-Bunq-Client-Request-Id", uuid.NewV4().String())
+	r.Header.Set("X-Bunq-Client-Request-Id", uuid.Must(uuid.NewV4()).String())
 	r.Header.Set("X-Bunq-Geolocation", "0 0 0 0 NL")
 	r.Header.Set("X-Bunq-Language", "en_US")
 	r.Header.Set("X-Bunq-Region", "en_US")


### PR DESCRIPTION
The uuid.NewV4() returns an error and value result. Use the uuid.Must to wrap it so we only use the value. This makes go-bunq buildable with the latest uuid package.