### PR TITLE
export client public key field to fix marshalling

### DIFF
--- a/installation.go
+++ b/installation.go
@@ -54,7 +54,7 @@ func (c *Client) CreateInstallation() (*Installation, error) {
 	}
 
 	body := struct {
-		string `json:"client_public_key"`
+		Field string `json:"client_public_key"`
 	}{string(publicKey)}
 	bodyJSON, err := json.Marshal(body)
 	if err != nil {


### PR DESCRIPTION
The field created in the body structure was not exported and therefor skipped by the json marshalling.